### PR TITLE
[Errno 2] No such file or directory: '/export/galaxy-central/database/files/tmp-toolshed-mtdFznSdY/hcluster_sg'

### DIFF
--- a/tools/hcluster_sg/tool_dependencies.xml
+++ b/tools/hcluster_sg/tool_dependencies.xml
@@ -3,7 +3,7 @@
     <package name="hcluster_sg" version="0.5.1">
         <install version="1.0">
             <actions>
-                <action type="shell_command">git clone https://github.com/douglasgscofield/hcluster.git</action>
+                <action type="shell_command">git clone https://github.com/douglasgscofield/hcluster.git hcluster_sg</action>
                 <action type="shell_command">make</action>
                 <action type="make_directory">$INSTALL_DIR/bin</action>
                 <action type="move_file">


### PR DESCRIPTION
The package name and git repo name don't match. This generates the error.
