### PR TITLE
Fix fasta_header_converter

### DIFF
--- a/tools/GAFA/GAFA.py
+++ b/tools/GAFA/GAFA.py
@@ -12,20 +12,20 @@ Sequence = collections.namedtuple('Sequence', ['header', 'sequence'])
 
 
 def FASTAReader_gen(fasta_filename):
-    fasta_file = open(fasta_filename)
-    line = fasta_file.readline()
-    while True:
-        if not line:
-            return
-        assert line.startswith('>'), "FASTA headers must start with >"
-        header = line.rstrip()
-        sequence_parts = []
+    with open(fasta_filename) as fasta_file:
         line = fasta_file.readline()
-        while line and line[0] != '>':
-            sequence_parts.append(line.rstrip())
+        while True:
+            if not line:
+                return
+            assert line.startswith('>'), "FASTA headers must start with >"
+            header = line.rstrip()
+            sequence_parts = []
             line = fasta_file.readline()
-        sequence = "".join(sequence_parts)
-        yield Sequence(header, sequence)
+            while line and line[0] != '>':
+                sequence_parts.append(line.rstrip())
+                line = fasta_file.readline()
+            sequence = "".join(sequence_parts)
+            yield Sequence(header, sequence)
 
 
 FASTA_MATCH_RE = re.compile(r'[^-]')

--- a/tools/TreeBest/fasta_header_converter.py
+++ b/tools/TreeBest/fasta_header_converter.py
@@ -1,7 +1,28 @@
 from __future__ import print_function
 
+import collections
 import json
 import optparse
+import sys
+
+Sequence = collections.namedtuple('Sequence', ['header', 'sequence'])
+
+
+def FASTAReader_gen(fasta_filename):
+    with open(fasta_filename) as fasta_file:
+        line = fasta_file.readline()
+        while True:
+            if not line:
+                return
+            assert line.startswith('>'), "FASTA headers must start with >"
+            header = line.rstrip()
+            sequence_parts = []
+            line = fasta_file.readline()
+            while line and line[0] != '>':
+                sequence_parts.append(line.rstrip())
+                line = fasta_file.readline()
+            sequence = "\n".join(sequence_parts)
+            yield Sequence(header, sequence)
 
 
 def read_gene_info(gene_info):
@@ -17,23 +38,25 @@ parser.add_option('-j', '--json', dest="input_gene_filename",
                   help='Gene feature information in JSON format')
 parser.add_option('-f', '--fasta', dest="input_fasta_filename",
                   help='Sequences in FASTA format')
+parser.add_option('-o', '--output', dest="output_fasta_filename",
+                  help='Output FASTA file name')
 options, args = parser.parse_args()
 
 if options.input_gene_filename is None:
     raise Exception('-j option must be specified')
-
 if options.input_fasta_filename is None:
     raise Exception('-f option must be specified')
+if options.output_fasta_filename is None:
+    raise Exception('-o option must be specified')
 
 with open(options.input_gene_filename) as json_fh:
     gene_info = json.load(json_fh)
 transcript_species_dict = read_gene_info(gene_info)
 
-with open(options.input_fasta_filename) as fasta_fh:
-    for line in fasta_fh:
-        line = line.rstrip()
-        if line.startswith(">"):
-            name = line[1:].lstrip()
-            print(">" + name + "_" + transcript_species_dict[name])
-        else:
-            print(line)
+with open(options.output_fasta_filename, 'w') as output_fasta_file:
+    for entry in FASTAReader_gen(options.input_fasta_filename):
+        name = entry.header[1:].lstrip()
+        if name not in transcript_species_dict:
+            print("Transcript '%s' not found in the gene feature information" % name, file=sys.stderr)
+            continue
+        output_fasta_file.write(">%s_%s\n%s\n" % (name, transcript_species_dict[name], entry.sequence))

--- a/tools/TreeBest/fasta_header_converter.xml
+++ b/tools/TreeBest/fasta_header_converter.xml
@@ -1,11 +1,11 @@
 <tool id="fasta_header_converter" name="FASTA header converter" version="0.1.1">
     <description>to append species information</description>
-    <command>
+    <command detect_errors="exit_code">
 <![CDATA[
 python '$__tool_directory__/fasta_header_converter.py'
 -f '$fastaFile'
 -j '$genesFile'
-> '$outputFile'
+-o '$outputFile'
 ]]>
     </command>
     <inputs>

--- a/tools/t_coffee/filter_by_fasta_ids.py
+++ b/tools/t_coffee/filter_by_fasta_ids.py
@@ -9,20 +9,20 @@ Sequence = collections.namedtuple('Sequence', ['header', 'sequence'])
 
 
 def FASTAReader_gen(fasta_filename):
-    fasta_file = open(fasta_filename)
-    line = fasta_file.readline()
-    while True:
-        if not line:
-            return
-        assert line.startswith('>'), "FASTA headers must start with >"
-        header = line.rstrip()
-        sequence_parts = []
+    with open(fasta_filename) as fasta_file:
         line = fasta_file.readline()
-        while line and line[0] != '>':
-            sequence_parts.append(line.rstrip())
+        while True:
+            if not line:
+                return
+            assert line.startswith('>'), "FASTA headers must start with >"
+            header = line.rstrip()
+            sequence_parts = []
             line = fasta_file.readline()
-        sequence = "".join(sequence_parts)
-        yield Sequence(header, sequence)
+            while line and line[0] != '>':
+                sequence_parts.append(line.rstrip())
+                line = fasta_file.readline()
+            sequence = "".join(sequence_parts)
+            yield Sequence(header, sequence)
 
 
 def target_match(target, search_entry):
@@ -47,7 +47,6 @@ def main():
 
     work_summary['wanted'] = len(targets)
 
-    # output = open(sys.argv[3], "w")
     for entry in FASTAReader_gen(sys.argv[2]):
         target_matched_results = target_match(targets, entry.header)
         if target_matched_results:


### PR DESCRIPTION
If a transcript is not found in the JSON file, write a message on stderr instead of failing.
Also:
- use `FASTAReader_gen` generator to read the FASTA file
- use `with` statement to open (and close) the FASTA file in `FASTAReader_gen` in `GAFA.py` and `t_coffee/filter_by_fasta_ids.py` .