### PR TITLE
replaces pipe with &&

### DIFF
--- a/tools/t_coffee/t_coffee.xml
+++ b/tools/t_coffee/t_coffee.xml
@@ -12,8 +12,8 @@
     <command>
 <![CDATA[
         #if str($input_type.filter_fasta) == 'yes'
-            #set $input = '-infile=stdin'
-            python '$__tool_directory__/filter_by_fasta_ids.py' '$input_type.identifiers' '$input_type.fasta_input' |
+            #set $input = 'temp.fasta'
+            python '$__tool_directory__/filter_by_fasta_ids.py' '$input_type.identifiers' '$input_type.fasta_input' > temp.fasta &&
         #end if
 
         #set $method_opt = ''


### PR DESCRIPTION
Due to [a bug](https://github.com/cbcrg/tcoffee/issues/9) in T-Coffee, piping the output of "Filter FASTA by IDs" to `t_coffee` produces a wrong alignment.