### PR TITLE
Don't exit immediately if lotus2 fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,27 +6,28 @@ on:
   repository_dispatch:
     types: [run-all-tool-tests-command]
 env:
-  GALAXY_RELEASE: release_22.05
   GALAXY_FORK: galaxyproject
+  GALAXY_BRANCH: release_22.05
   MAX_CHUNKS: 40
 jobs:
   setup:
-    name: Setup cache
+    name: Setup cache and determine changed repositories
     if: ${{ github.repository_owner == 'TGAC' }}
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.get-fork-branch.outputs.branch }}
+      galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
       fork: ${{ steps.get-fork-branch.outputs.fork }}
-      galaxy_head_sha: ${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
-      nchunks: ${{ steps.get-chunks.outputs.nchunks }}
-      chunk_list: ${{ steps.get-chunks.outputs.chunk_list }}
+      branch: ${{ steps.get-fork-branch.outputs.branch }}
+      repository-list: ${{ steps.discover.outputs.repository-list }}
+      chunk-count: ${{ steps.discover.outputs.chunk-count }}
+      chunk-list: ${{ steps.discover.outputs.chunk-list }}
     strategy:
       matrix:
         python-version: ['3.7']
     steps:
     - name: Add reaction
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v2
       with:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -36,12 +37,12 @@ jobs:
       id: get-fork-branch
       run: |
         TMP="${{ github.event.client_payload.slash_command.args.named.fork }}"
-        echo "::set-output name=fork::${TMP:-$GALAXY_FORK}"
+        echo "fork=${TMP:-$GALAXY_FORK}" >> $GITHUB_OUTPUT
         TMP="${{ github.event.client_payload.slash_command.args.named.branch }}"
-        echo "::set-output name=branch::${TMP:-$GALAXY_RELEASE}"
+        echo "branch=${TMP:-$GALAXY_BRANCH}" >> $GITHUB_OUTPUT
     - name: Determine latest commit in the Galaxy repo
       id: get-galaxy-sha
-      run: echo "::set-output name=galaxy_head_sha::$(git ls-remote https://github.com/${{ steps.get-fork-branch.outputs.fork }}/galaxy refs/heads/${{ steps.get-fork-branch.outputs.branch }} | cut -f1)"
+      run: echo "galaxy-head-sha=$(git ls-remote https://github.com/${{ steps.get-fork-branch.outputs.fork }}/galaxy refs/heads/${{ steps.get-fork-branch.outputs.branch }} | cut -f1)" >> $GITHUB_OUTPUT
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
@@ -50,45 +51,39 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
     # Install the `wheel` package so that when installing other packages which
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install wheel
       run: pip install wheel
-    - name: Install Planemo
-      run: pip install planemo
-    - name: Fake a Planemo run to update cache
-      if: steps.cache-pip.outputs.cache-hit != 'true'
-      run: |
-        touch tool.xml
-        PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_source 'https://github.com/${{ steps.get-fork-branch.outputs.fork }}/galaxy' --galaxy_branch "${{ steps.get-fork-branch.outputs.branch }}" --galaxy_python_version ${{ matrix.python-version }}
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
-    - name: Get approximate number of tools and compute number of chunks
-      id: get-chunks
-      run: |
-        nchunks=$(find data_managers/ tools/ tool_collections/ -iname '*.xml' | grep -v 'data_manager_conf.xml\|datatypes_conf.xml\|macro\|repository_dependencies.xml\|test-data/\|tool_dependencies.xml' | xargs grep -l '<tool ' | wc -l)
-        if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
-            nchunks=$MAX_CHUNKS
-        elif [ "$nchunks" -eq 0 ]; then
-            nchunks=1
-        fi
-        echo "::set-output name=nchunks::$nchunks"
-        echo "::set-output name=chunk_list::[$(seq -s ", " 0 $(($nchunks - 1)))]"
+    - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
+      uses: galaxyproject/planemo-ci-action@v1
+      id: discover
+      with:
+        create-cache: ${{ steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true' }}
+        galaxy-fork: ${{ steps.get-fork-branch.outputs.fork }}
+        galaxy-branch: ${{ steps.get-fork-branch.outputs.branch }}
+        max-chunks: ${{ env.MAX_CHUNKS }}
+        python-version: ${{ matrix.python-version }}
+    - name: Show repository list
+      run: echo '${{ steps.discover.outputs.repository-list }}'
     - name: Show chunks
       run: |
-        echo 'Using ${{ steps.get-chunks.outputs.nchunks }} chunks (${{ steps.get-chunks.outputs.chunk_list }})'
+        echo 'Using ${{ steps.discover.outputs.chunk-count }} chunks (${{ steps.discover.outputs.chunk-list }})'
 
   test:
     name: Test tools
     # This job runs on Linux
     runs-on: ubuntu-latest
     needs: setup
+    if: ${{ needs.setup.outputs.repository-list != '' }}
     strategy:
       fail-fast: false
       matrix:
-        chunk: ${{ fromJson(needs.setup.outputs.chunk_list) }}
+        chunk: ${{ fromJson(needs.setup.outputs.chunk-list) }}
         python-version: ['3.7']
     services:
       postgres:
@@ -113,35 +108,23 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
-    - name: Install Planemo
-      run: pip install planemo
-    - name: Planemo ci_find_tools, chunked
-      run: planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk }} --exclude test_repositories --exclude packages --exclude deprecated --exclude_from .tt_skip --group_tools --output tool.list
-    - name: Show tools chunk list
-      run: cat tool.list
-    - name: Planemo test tools
-      run: |
-        mkdir json_output
-        while read -r TOOL_GROUP; do
-            # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL_GROUP
-            if echo $TOOL_GROUP | grep -qf .tt_biocontainer_skip; then
-                PLANEMO_OPTIONS=""
-            else
-                PLANEMO_OPTIONS="--biocontainers --no_dependency_resolution --no_conda_auto_init"
-            fi
-            json=$(mktemp -u -p json_output --suff .json)
-            PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source "https://github.com/${{ needs.setup.outputs.fork }}/galaxy" --galaxy_branch "${{ needs.setup.outputs.branch }}" --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" $TOOL_GROUP || true
-            docker system prune --all --force --volumes || true
-        done < tool.list
-    - name: Merge tool_test_output.json files
-      run: planemo merge_test_reports json_output/*.json tool_test_output.json
-    - name: Create tool_test_output.html
-      run: planemo test_reports tool_test_output.json --test_output tool_test_output.html
-    - name: Copy artifacts into place
-      run: |
-        mkdir upload
-        mv tool_test_output.json tool_test_output.html upload/
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v1
+      id: cpu-cores
+    - name: Planemo test
+      uses: galaxyproject/planemo-ci-action@v1
+      id: test
+      with:
+        mode: test
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        galaxy-fork: ${{ needs.setup.outputs.fork }}
+        galaxy-branch: ${{ needs.setup.outputs.branch }}
+        chunk: ${{ matrix.chunk }}
+        chunk-count: ${{ needs.setup.outputs.chunk-count }}
+        galaxy-slots: ${{ steps.cpu-cores.outputs.count }}
+        # Limit each test to 15 minutes
+        test_timeout: 900
     - uses: actions/upload-artifact@v3
       with:
         name: 'Tool test output ${{ matrix.chunk }}'
@@ -172,37 +155,25 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
-    - name: Install Planemo
-      run: pip install planemo
-    - name: Install jq
-      run: sudo apt-get install jq
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Combine outputs
-      run: find artifacts/ -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
-    - name: Create tool_test_output.html
-      run: planemo test_reports tool_test_output.json --test_output tool_test_output.html
-    - name: Copy artifacts into place
-      run: |
-        mkdir upload
-        mv tool_test_output.json tool_test_output.html upload/
+      uses: galaxyproject/planemo-ci-action@v1
+      id: combine
+      with:
+        mode: combine
+        html-report: true
     - uses: actions/upload-artifact@v3
       with:
         name: 'All tool test results'
         path: upload
-
     - name: Create URL to the run output
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
       id: vars
-      run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-    - name: Gather statistics
-      if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      id: stats
-      run: echo ::set-output name=statistics::$(jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | sed 's/"//g' | sort | uniq -c)
+      run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
     - name: Create comment
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v2
       with:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -210,14 +181,13 @@ jobs:
         body: |
           Summary:
 
-          ${{ steps.stats.outputs.statistics }}
+          ${{ steps.combine.outputs.statistics }}
 
           [Find all tool test results here][1]
 
           [1]: ${{ steps.vars.outputs.run-url }}
-    - name: Check status of combined outputs
-      run: |
-        if jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | grep -v "success"; then
-            echo "Unsuccessful tests found, inspect the 'All tool test results' artifact for details."
-            exit 1
-        fi
+    - name: Check outputs
+      uses: galaxyproject/planemo-ci-action@v1
+      id: check
+      with:
+        mode: check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,15 @@
 name: Galaxy Tool Linting and Tests for push and PR
 on: [push, pull_request]
 env:
-  GALAXY_REPO: https://github.com/galaxyproject/galaxy
-  GALAXY_RELEASE: release_22.05
+  GALAXY_FORK: galaxyproject
+  GALAXY_BRANCH: release_22.05
   MAX_CHUNKS: 4
+  MAX_FILE_SIZE: 1M
+concurrency:
+  # Group runs by PR, but keep runs on the default branch separate
+  # because we do not want to cancel ToolShed uploads
+  group: pr-${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && github.run_number || github.ref }}
+  cancel-in-progress: true
 jobs:
   # the setup job does two things:
   # 1. cache the pip cache and .planemo
@@ -16,10 +22,12 @@ jobs:
     name: Setup cache and determine changed repositories
     runs-on: ubuntu-latest
     outputs:
-      galaxy_head_sha: ${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
-      commit_range: ${{ steps.get-commit-range.outputs.commit_range }}
-      nchunks: ${{ steps.get-chunks.outputs.nchunks }}
-      chunk_list: ${{ steps.get-chunks.outputs.chunk_list }}
+      galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+      repository-list: ${{ steps.discover.outputs.repository-list }}
+      tool-list: ${{ steps.discover.outputs.tool-list }}
+      chunk-count: ${{ steps.discover.outputs.chunk-count }}
+      chunk-list: ${{ steps.discover.outputs.chunk-list }}
+      commit-range: ${{ steps.discover.outputs.commit-range }}
     strategy:
       matrix:
         python-version: ['3.7']
@@ -33,191 +41,134 @@ jobs:
         echo 'base_ref: ${{ github.base_ref }}'
         echo 'event.before: ${{ github.event.before }}'
         echo 'event.after: ${{ github.event.after }}'
+    - name: Determine latest commit in the Galaxy repo
+      id: get-galaxy-sha
+      run: echo "galaxy-head-sha=$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)" >> $GITHUB_OUTPUT
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Determine latest commit in the Galaxy repo
-      id: get-galaxy-sha
-      run: echo "::set-output name=galaxy_head_sha::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)"
     - name: Cache .cache/pip
       uses: actions/cache@v3
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
     - name: Cache .planemo
       uses: actions/cache@v3
       id: cache-planemo
       with:
         path: ~/.planemo
-        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
     # Install the `wheel` package so that when installing other packages which
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install wheel
       run: pip install wheel
-    - name: Install Planemo and flake8
-      run: pip install planemo flake8 flake8-import-order
-    - name: Fake a Planemo run to update cache
-      if: steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true'
-      run: |
-        touch tool.xml
-        PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_source $GALAXY_REPO --galaxy_branch $GALAXY_RELEASE
+    - name: Install flake8
+      run: pip install flake8 flake8-import-order
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    # The range of commits to check for changes is:
-    # - `origin/master...` for all events happening on a feature branch
-    # - for events on the master branch we compare against the sha before the event
-    #   (note that this does not work for feature branch events since we want all
-    #   commits on the feature branch and not just the commits of the last event)
-    # - for pull requests we compare against the 1st ancestor, given the current
-    #   HEAD is the merge between the PR branch and the base branch
-    - name: Set commit range (push to the feature branch)
-      if: github.ref != 'refs/heads/master' && github.event_name == 'push'
-      run: |
-        git fetch origin master
-        echo "COMMIT_RANGE=origin/master..." >> $GITHUB_ENV
-    - name: Set commit range (push to the master branch, e.g. merge)
-      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-      run: echo "COMMIT_RANGE=${{ github.event.before }}.." >> $GITHUB_ENV
-    - name: Set commit range (pull request)
-      if: github.event_name == 'pull_request'
-      run: echo "COMMIT_RANGE=HEAD~.." >> $GITHUB_ENV
-    - id: get-commit-range
-      run: echo "::set-output name=commit_range::$COMMIT_RANGE"
-    - name: Planemo ci_find_repos
-      run: planemo ci_find_repos --changed_in_commit_range $COMMIT_RANGE --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_repositories.list
-    - name: Show repo list
-      run: cat changed_repositories.list
-    - uses: actions/upload-artifact@v3
+    - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
+      uses: galaxyproject/planemo-ci-action@v1
+      id: discover
       with:
-        name: Workflow artifacts
-        path: changed_repositories.list
-    - name: Planemo ci_find_tools for the changed repos
-      run: |
-        touch changed_tools.list
-        if [ -s changed_repositories.list ]; then
-            planemo ci_find_tools --output changed_tools.list $(cat changed_repositories.list)
-        fi
+        create-cache: ${{ steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true' }}
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        max-chunks: ${{ env.MAX_CHUNKS }}
+        python-version: ${{ matrix.python-version }}
+    - name: Show commit range
+      run: echo '${{ steps.discover.outputs.commit-range }}'
+    - name: Show repository list
+      run: echo '${{ steps.discover.outputs.repository-list }}'
     - name: Show tool list
-      run: cat changed_tools.list
-    - name: Compute chunks
-      id: get-chunks
-      run: |
-        nchunks=$(wc -l < changed_tools.list)
-        if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
-            nchunks=$MAX_CHUNKS
-        elif [ "$nchunks" -eq 0 ]; then
-            nchunks=1
-        fi
-        echo "::set-output name=nchunks::$nchunks"
-        echo "::set-output name=chunk_list::[$(seq -s ", " 0 $(($nchunks - 1)))]"
+      run: echo '${{ steps.discover.outputs.tool-list }}'
     - name: Show chunks
       run: |
-        echo 'Using ${{ steps.get-chunks.outputs.nchunks }} chunks (${{ steps.get-chunks.outputs.chunk_list }})'
+        echo 'Using ${{ steps.discover.outputs.chunk-count }} chunks (${{ steps.discover.outputs.chunk-list }})'
 
   # Planemo lint the changed repositories
   lint:
-    name: Lint tools
+    name: Lint tool-list
     needs: setup
+    if: ${{ needs.setup.outputs.repository-list != '' || needs.setup.outputs.tool-list != '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.7']
     steps:
-    # checkout the repository
-    # and use it as the current working directory
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v3
-      with:
-        name: Workflow artifacts
-        path: ../workflow_artifacts/
     - name: Cache .cache/pip
       uses: actions/cache@v3
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
-    - name: Install Planemo
-      run: pip install planemo
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Planemo lint
-      run: |
-        set -e
-        while read -r DIR; do
-            planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR";
-        done < ../workflow_artifacts/changed_repositories.list
-    - name: Planemo ci_find_tools for the commit range
-      run: planemo ci_find_tools --changed_in_commit_range ${{ needs.setup.outputs.commit_range }} --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_tools.list
-    - name: Check if each changed tool is in the list of changed repositories
-      run: |
-        set -e
-        while read -r TOOL; do
-            # Check if any changed repo dir is a substring of $TOOL
-            if ! echo $TOOL | grep -qf ../workflow_artifacts/changed_repositories.list; then
-                echo "Tool $TOOL not in changed repositories list: .shed.yml file missing" >&2
-                exit 1
-            fi
-        done < changed_tools.list
+      uses: galaxyproject/planemo-ci-action@v1
+      id: lint
+      with:
+        mode: lint
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        tool-list: ${{ needs.setup.outputs.tool-list }}
+    - uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: 'Tool linting output'
+        path: lint_report.txt
 
   # flake8 of Python scripts in the changed repositories
   flake8:
     name: Lint Python scripts
     needs: setup
+    if: ${{ needs.setup.outputs.repository-list != '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.7']
     steps:
-    # checkout the repository to master
-    # and use it as the current working directory
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v3
-      with:
-        name: Workflow artifacts
-        path: ../workflow_artifacts/
     - name: Cache .cache/pip
       uses: actions/cache@v3
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Install flake8
       run: pip install flake8 flake8-import-order
     - name: Flake8
-      run: |
-        if [ -s ../workflow_artifacts/changed_repositories.list ]; then
-            flake8 $(cat ../workflow_artifacts/changed_repositories.list)
-        fi
+      run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8 --output-file pylint_report.txt --tee
+    - uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: 'Python linting output'
+        path: pylint_report.txt
 
   lintr:
     name: Lint R scripts
     needs: setup
-    runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.repository-list != '' }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-20.04]
         r-version: ['release']
     steps:
-    # checkout the repository to master
-    # and use it as the current working directory
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
-    - uses: actions/download-artifact@v3
-      with:
-        name: Workflow artifacts
-        path: ../workflow_artifacts/
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.r-version }}
@@ -225,19 +176,21 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.R_LIBS_USER }}
-        key: r_cache_${{ matrix.r-version }}
+        key: r_cache_${{ matrix.os }}_${{ matrix.r-version }}
     - name: Install non-R lintr dependencies
-      run: sudo apt-get install libcurl4-openssl-dev 
+      run: sudo apt-get install libcurl4-openssl-dev
     - name: Install lintr
       run: |
         install.packages('remotes')
         remotes::install_cran("lintr")
       shell: Rscript {0}
+    - name: Save repositories to file
+      run: echo '${{ needs.setup.outputs.repository-list }}' > repository_list.txt
     - name: lintr
       run: |
         library(lintr)
-        linters <- linters_with_defaults(line_length_linter = NULL, object_usage_linter = NULL)
-        con <- file("../workflow_artifacts/changed_repositories.list", "r")
+        linters <- linters_with_defaults(line_length_linter = NULL, cyclocomp_linter = NULL, object_usage_linter = NULL)
+        con <- file("repository_list.txt", "r")
         status <- 0
         while (TRUE) {
           repo <- readLines(con, n = 1)
@@ -250,23 +203,56 @@ jobs:
             for (l in lnt) {
               rel_path <- paste(repo, l$filename, sep="/")
               write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message, paste("(", l$line, ")")), stderr())
+              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message, paste("(", l$line, ")")), "rlint_report.txt", append=TRUE)
             }
           }
         }
         quit(status = status)
       shell: Rscript {0}
+    - uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: 'R linting output'
+        path: rlint_report.txt
+
+  file_sizes:
+    name: Check file sizes
+    needs: setup
+    if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.repository-list != '' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Check file sizes
+      run: |
+        touch file_size_report.txt
+        git diff --diff-filter=d --name-only ${{ needs.setup.outputs.commit-range }} > git.diff
+        while read line; do
+          find "$line" -type f -size +${{ env.MAX_FILE_SIZE }} >> file_size_report.txt
+        done < git.diff
+        if [[ -s file_size_report.txt ]]; then
+          echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
+          cat file_size_report.txt
+          exit 1
+        fi
+    - uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: 'File size report'
+        path: file_size_report.txt
 
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests
   test:
     name: Test tools
-    # This job runs on Linux
-    runs-on: ubuntu-latest
     needs: setup
+    if: ${{ needs.setup.outputs.repository-list != '' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        chunk: ${{ fromJson(needs.setup.outputs.chunk_list) }}
+        chunk: ${{ fromJson(needs.setup.outputs.chunk-list) }}
         python-version: ['3.7']
     services:
       postgres:
@@ -278,68 +264,43 @@ jobs:
         ports:
           - 5432:5432
     steps:
-    # checkout the repository
-    # and use it as the current working directory
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v3
-      with:
-        name: Workflow artifacts
-        path: ../workflow_artifacts/
     - name: Cache .cache/pip
       uses: actions/cache@v3
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Cache .planemo
       uses: actions/cache@v3
       id: cache-planemo
       with:
         path: ~/.planemo
-        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
-    - name: Install Planemo
-      run: pip install planemo
-    - name: Planemo ci_find_tools for the change repos, chunked
-      run: |
-        touch changed_tools_chunk.list
-        if [ -s ../workflow_artifacts/changed_repositories.list ]; then
-          planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk }} --group_tools --output changed_tools_chunk.list $(cat ../workflow_artifacts/changed_repositories.list)
-        fi
-    - name: Show changed tools chunk list
-      run: cat changed_tools_chunk.list
-    - name: Planemo test tools
-      run: |
-        mkdir json_output
-        while read -r TOOL_GROUP; do
-            # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL_GROUP
-            if echo $TOOL_GROUP | grep -qf .tt_biocontainer_skip; then
-                PLANEMO_OPTIONS=""
-            else
-                PLANEMO_OPTIONS="--biocontainers --no_dependency_resolution --no_conda_auto_init"
-            fi
-            json=$(mktemp -u -p json_output --suff .json)
-            PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source $GALAXY_REPO --galaxy_branch $GALAXY_RELEASE --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" $TOOL_GROUP || true
-            docker system prune --all --force --volumes || true
-        done < changed_tools_chunk.list
-        if [ ! -s changed_tools_chunk.list ]; then
-            echo '{"tests":[]}' > "$(mktemp -u -p json_output --suff .json)"
-        fi
-    - name: Merge tool_test_output.json files
-      run: planemo merge_test_reports json_output/*.json tool_test_output.json
-    - name: Create tool_test_output.html
-      run: planemo test_reports tool_test_output.json --test_output tool_test_output.html
-    - name: Copy artifacts into place
-      run: |
-        mkdir upload
-        mv tool_test_output.json tool_test_output.html upload/
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v1
+      id: cpu-cores
+    - name: Planemo test
+      uses: galaxyproject/planemo-ci-action@v1
+      id: test
+      with:
+        mode: test
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        chunk: ${{ matrix.chunk }}
+        chunk-count: ${{ needs.setup.outputs.chunk-count }}
+        galaxy-slots: ${{ steps.cpu-cores.outputs.count }}
+        # Limit each test to 15 minutes
+        test_timeout: 900
     - uses: actions/upload-artifact@v3
       with:
-        name: 'Tool test output ${{ matrix.chunk  }}'
+        name: 'Tool test output ${{ matrix.chunk }}'
         path: upload
 
   # - combine the results of the test chunks (which will never fail due
@@ -350,11 +311,11 @@ jobs:
   combine_outputs:
     name: Combine chunked test results
     needs: [setup, test]
+    if: ${{ needs.setup.outputs.repository-list != '' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.7']
-    # This job runs on Linux
-    runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -367,39 +328,32 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
-    - name: Install Planemo
-      run: pip install planemo
-    - name: Install jq
-      run: sudo apt-get install jq
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Combine outputs
-      run: find artifacts/ -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
-    - name: Create tool_test_output.html
-      run: planemo test_reports tool_test_output.json --test_output tool_test_output.html
-    - name: Copy artifacts into place
-      run: |
-        mkdir upload
-        mv tool_test_output.json tool_test_output.html upload/
+      uses: galaxyproject/planemo-ci-action@v1
+      id: combine
+      with:
+        mode: combine
+        html-report: true
     - uses: actions/upload-artifact@v3
       with:
         name: 'All tool test results'
         path: upload
-    - name: Check status of combined outputs
-      run: |
-        if jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | grep -v "success"; then
-            echo "Unsuccessful tests found, inspect the 'All tool test results' artifact for details."
-            exit 1
-        fi
+    - name: Check outputs
+      uses: galaxyproject/planemo-ci-action@v1
+      id: check
+      with:
+        mode: check
 
   # deploy the tools to the toolsheds (first TTS for testing)
   deploy:
     name: Deploy
     needs: [setup, lint, flake8, lintr, combine_outputs]
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'TGAC' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.7']
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.repository_owner == 'TGAC'
     steps:
     - uses: actions/checkout@v3
       with:
@@ -407,30 +361,46 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v3
-      with:
-        name: Workflow artifacts
-        path: ../workflow_artifacts/
     - name: Cache .cache/pip
       uses: actions/cache@v3
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
-    - name: Install Planemo
-      run: pip install planemo
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Deploy on testtoolshed
-      env:
-        SHED_KEY: ${{ secrets.TTS_API_KEY }}
-      run: |
-        while read -r DIR; do
-            planemo shed_update --shed_target testtoolshed --shed_key "${{ env.SHED_KEY }}" --force_repository_creation "$DIR" || exit 1;
-        done < ../workflow_artifacts/changed_repositories.list
+      uses: galaxyproject/planemo-ci-action@v1
+      with:
+        mode: deploy
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        shed-target: testtoolshed
+        shed-key: ${{ secrets.TTS_API_KEY }}
       continue-on-error: true
     - name: Deploy on toolshed
-      env:
-        SHED_KEY: ${{ secrets.TS_API_KEY }}
-      run: |
-        while read -r DIR; do
-            planemo shed_update --shed_target toolshed --shed_key "${{ env.SHED_KEY }}" --force_repository_creation "$DIR" || exit 1;
-        done < ../workflow_artifacts/changed_repositories.list
+      uses: galaxyproject/planemo-ci-action@v1
+      with:
+        mode: deploy
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        shed-target: toolshed
+        shed-key: ${{ secrets.TS_API_KEY }}
+
+  determine-success:
+    name: Check workflow success
+    needs: [setup, lint, flake8, lintr, file_sizes, combine_outputs]
+    if: ${{ always() && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check tool lint status
+      if: ${{ needs.lint.result != 'success' && needs.flake8.result != 'skipped' }}
+      run: exit 1
+    - name: Indicate Python script lint status
+      if: ${{ needs.flake8.result != 'success' && needs.flake8.result != 'skipped' }}
+      run: exit 1
+    - name: Indicate R script lint status
+      if: ${{ needs.lintr.result != 'success' && needs.lintr.result != 'skipped' }}
+      run: exit 1
+    - name: Indicate file size check status
+      if: ${{ needs.file_sizes.result != 'success' && needs.file_sizes.result != 'skipped' }}
+      run: exit 1
+    - name: Check tool test status
+      if: ${{ needs.combine_outputs.result != 'success' && needs.combine_outputs.result != 'skipped' }}
+      run: exit 1

--- a/.github/workflows/slash.yaml
+++ b/.github/workflows/slash.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Slash Command Dispatch
         if: github.repository_owner == 'TGAC'
-        uses: peter-evans/slash-command-dispatch@v2
+        uses: peter-evans/slash-command-dispatch@v3
         with:
           token: ${{ secrets.PAT }}
           commands: |

--- a/tools/lotus2/lotus2.xml
+++ b/tools/lotus2/lotus2.xml
@@ -1,4 +1,4 @@
-<tool id="lotus2" name="LotuS2" version="@VERSION@" profile="20.09">
+<tool id="lotus2" name="LotuS2" version="@VERSION@+galaxy1" profile="20.09">
     <description>fast OTU processing pipeline</description>
     <macros>
         <token name="@VERSION@">2.21</token>
@@ -82,6 +82,8 @@ mkdir input
     cat '$generated_mapping' &&
     #set map = $generated_mapping
 #end if
+
+set +e &&
 
 lotus2
 -i input/


### PR DESCRIPTION
Disable `set -e`, which is automatically enforced by the "20.09" tool profile.
Otherwise output.zip is not created, making more difficult to debug issues.

Also:
- Update GitHub actions from tools-iuc