### PR TITLE
Use collection names in Lotu2 mapping

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -329,8 +329,8 @@ jobs:
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup.outputs.chunk-count }}
         galaxy-slots: ${{ steps.cpu-cores.outputs.count }}
-        # Limit each test to 15 minutes
-        test_timeout: 900
+        # Limit each test to 20 minutes
+        test_timeout: 1200
     - uses: actions/upload-artifact@v7
       with:
         name: 'Tool test output ${{ matrix.chunk }}'

--- a/tools/lotus2/lotus2.xml
+++ b/tools/lotus2/lotus2.xml
@@ -1,4 +1,4 @@
-<tool id="lotus2" name="LotuS2" version="@VERSION@+galaxy0" profile="20.09">
+<tool id="lotus2" name="LotuS2" version="@VERSION@+galaxy1" profile="20.09">
     <description>fast OTU processing pipeline</description>
     <macros>
         <token name="@VERSION@">2.32</token>

--- a/tools/lotus2/lotus2.xml
+++ b/tools/lotus2/lotus2.xml
@@ -210,7 +210,7 @@ ${fn}#slurp
 SMPL${i}	${symlink_basename($f)}	a
     #end for
 #else:
-    #for $i, $f in enumerate($inputs.pair_input):
+    #for $f in $inputs.pair_input:
 #set $sample_id = re.sub('[^\w\-_.]', '_', str($f.element_identifier))
 ${sample_id}	${symlink_basename($f.forward.dataset)},${symlink_basename($f.reverse.dataset)}	a
     #end for

--- a/tools/lotus2/lotus2.xml
+++ b/tools/lotus2/lotus2.xml
@@ -415,12 +415,12 @@ ${sample_id}	${symlink_basename($f.forward.dataset)},${symlink_basename($f.rever
                     </collection>
                 </param>
             </conditional>
-            <param name="map" value="mapping_paired.txt" ftype="tabular" />
             <section name="tax_args">
                 <param name="lulu" value="true" />
             </section>
             <output name="otu" file="OTU_paired.txt" compare="sim_size" />
             <output name="otu_fna" file="OTU_paired.fna" compare="sim_size" />
+            <output name="mapping" file="mapping_paired.txt" />
         </test>
     </tests>
 

--- a/tools/lotus2/lotus2.xml
+++ b/tools/lotus2/lotus2.xml
@@ -211,7 +211,8 @@ SMPL${i}	${symlink_basename($f)}	a
     #end for
 #else:
     #for $i, $f in enumerate($inputs.pair_input):
-SMPL${i}	${symlink_basename($f.forward.dataset)},${symlink_basename($f.reverse.dataset)}	a
+#set $sample_id = re.sub('[^\w\-_.]', '_', str($f.element_identifier))
+${sample_id}	${symlink_basename($f.forward.dataset)},${symlink_basename($f.reverse.dataset)}	a
     #end for
 #end if
 ]]></configfile>

--- a/tools/lotus2/test-data/mapping_paired.txt
+++ b/tools/lotus2/test-data/mapping_paired.txt
@@ -1,2 +1,2 @@
 #SampleID	fastqFile	SequencingRun
-SMPL0	Arabidopsis_R1.fastqsanger.gz,Arabidopsis_R2.fastqsanger.gz	a
+Anh_sample	Arabidopsis_R1.fastqsanger.gz,Arabidopsis_R2.fastqsanger.gz	a


### PR DESCRIPTION
With this change, the name of the Galaxy collection is used as the LotuS2 mapping sample ID. Previously, the generated mapping used generic IDs such as SMPL0, which required a separate mapping file to be provided. The added test checks whether a linked collection element named “Anh_sample” generates a mapping file in which “Anh_sample” is used as the #SampleID.